### PR TITLE
Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang
+
+COPY src /go/src
+COPY pub /go/pub
+COPY config.json /go/pub/
+RUN go-wrapper install hound/cmds/houndd
+
+EXPOSE 6080
+
+ENTRYPOINT ["bin/houndd", "-conf", "/go/pub/config.json"]

--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ Which brings us to...
 
 Yup, that's it. You can proxy requests to the Go service through Apache/nginx/etc., but that's not required.
 
+## Docker
+* docker 1.4+
+
+You should follow the quickstart guide up to step (2) and then run:
+
+    $ docker build . -t houndd
+    $ docker run -it --rm -p 0.0.0.0:6080:6080 --name houndd houndd
+
+You should be able to navigate to [http://localhost:6080/](http://localhost:6080/) as usual.
+
 ## Support
 
 Currently Hound is only tested on MacOS and CentOS, but it should work on any *nix system. There is no plan to support Windows, and we've heard that it fails to compile on Windows, but we would be happy to accept a PR that fixes this!

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Yup, that's it. You can proxy requests to the Go service through Apache/nginx/et
 ## Docker
 * docker 1.4+
 
-You should follow the quickstart guide up to step (2) and then run:
+You should follow the quickstart guide up to step (3) and then run:
 
     $ docker build . -t houndd
     $ docker run -it --rm -p 0.0.0.0:6080:6080 --name houndd houndd


### PR DESCRIPTION
Add a Dockerfile and some instructions on how to use it.

Uses the official [golang Repository](https://registry.hub.docker.com/_/golang/) image.