### PR TITLE
Fix deletion of repos cache with same prefix

### DIFF
--- a/src/hound/searcher/searcher.go
+++ b/src/hound/searcher/searcher.go
@@ -56,7 +56,9 @@ func expungeOldIndexes(sha, gitDir string) error {
 
 	name := fmt.Sprintf("%s-%s", filepath.Base(gitDir), sha)
 
-	dirs, err := filepath.Glob(fmt.Sprintf("%s-*", gitDir))
+	// prevents directories with similar prefix to be matched together, for
+	// example `docker-asdf...` and `docker-flatten-asdf...`
+	dirs, err := filepath.Glob(fmt.Sprintf("%s-[0-9a-f]{40}$", gitDir))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Right now the searcher use regex `repoName-*` which will wrongly identifies directories with same prefix. For example when scanning for `docker` with an existing `docker-flatten` in cache:

- docker-e556913b0536092478b0b2fa8f2e08eb47ba27d3
- docker-flatten-3d72ab74be80e2f8af2b0b8742906350b319655e

The result is that `docker-flatten-3d72ab74be80e2f8af2b0b8742906350b319655e`
will be identified as invalid and will be deleted.

This patch applies the same bandaid found in another regex in the same context. But perhaps directory structure can be simplied so we dont have to use regex to identify related directories.