### PR TITLE
Fix houndd server location output line

### DIFF
--- a/src/hound/cmds/houndd/main.go
+++ b/src/hound/cmds/houndd/main.go
@@ -304,7 +304,13 @@ func main() {
 		panic(err)
 	}
 
-	info_log.Printf("All indexes built, running server at http://localhost%s...\n", *flagAddr)
+
+	formattedAddress := *flagAddr
+	if (0 == strings.Index(*flagAddr, ":")) {
+		formattedAddress = "localhost" + *flagAddr
+	}
+
+	info_log.Printf("All indexes built, running server at http://%s...\n", formattedAddress)
 
 	if err := runHttp(*flagAddr, *flagRoot, *flagProd, &cfg, idx); err != nil {
 		panic(err)


### PR DESCRIPTION
When running houndd the output status line doesn't handle --addr with a hostname included.
I've never written any go before, so this might be complete nonsense :)

**Before**
./bin/houndd
All indexes built, running server at http://localhost:6080...

./bin/houndd --addr 127.0.0.1:6800
All indexes built, running server at http://localhost127.0.0.1:6800...

**AFTER**
./bin/houndd
All indexes built, running server at http://localhost:6080...

./bin/houndd --addr 127.0.0.1:6800
All indexes built, running server at http://127.0.0.1:6800...


