### PR TITLE
Refactor internal VCS api and add Mercurial support

### DIFF
--- a/src/hound/config/config.go
+++ b/src/hound/config/config.go
@@ -6,11 +6,15 @@ import (
 	"path/filepath"
 )
 
-const defaultMsBetweenPoll = 30000
+const (
+	defaultMsBetweenPoll = 30000
+	defaultVCS           = "git"
+)
 
 type Repo struct {
 	Url            string `json:"url"`
 	MsBetweenPolls int    `json:"ms-between-poll"`
+	VCS            string `json:"vcs"`
 }
 
 type Config struct {
@@ -41,6 +45,9 @@ func (c *Config) LoadFromFile(filename string) error {
 	for _, repo := range c.Repos {
 		if repo.MsBetweenPolls == 0 {
 			repo.MsBetweenPolls = defaultMsBetweenPoll
+		}
+		if repo.VCS == "" {
+			repo.VCS = defaultVCS
 		}
 	}
 

--- a/src/hound/vcs/git.go
+++ b/src/hound/vcs/git.go
@@ -1,0 +1,68 @@
+package vcs
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func init() {
+	RegisterVCS("git", &GitDriver{})
+}
+
+type GitDriver struct{}
+
+func (g *GitDriver) HeadHash(dir string) (string, error) {
+	cmd := exec.Command(
+		"git",
+		"rev-parse",
+		"HEAD")
+	cmd.Dir = dir
+	r, err := cmd.StdoutPipe()
+	if err != nil {
+		return "", err
+	}
+	defer r.Close()
+
+	if err := cmd.Start(); err != nil {
+		return "", err
+	}
+
+	var buf bytes.Buffer
+
+	if _, err := io.Copy(&buf, r); err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(buf.String()), cmd.Wait()
+}
+
+func (g *GitDriver) Pull(dir string) (string, error) {
+	cmd := exec.Command("git", "pull")
+	cmd.Dir = dir
+	err := cmd.Run()
+	if err != nil {
+		return "", err
+	}
+
+	return g.HeadHash(dir)
+}
+
+func (g *GitDriver) Clone(dir, url string) (string, error) {
+	par, rep := filepath.Split(dir)
+	cmd := exec.Command(
+		"git",
+		"clone",
+		url,
+		rep)
+	cmd.Dir = par
+	cmd.Stdout = ioutil.Discard
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+
+	return g.HeadHash(dir)
+}

--- a/src/hound/vcs/vcs.go
+++ b/src/hound/vcs/vcs.go
@@ -1,0 +1,64 @@
+package vcs
+
+import (
+	"fmt"
+	"os"
+)
+
+type Driver interface {
+	Clone(dir, url string) (string, error)
+	Pull(dir string) (string, error)
+	HeadHash(dir string) (string, error)
+}
+
+var drivers = make(map[string]Driver)
+
+func RegisterVCS(name string, driver Driver) {
+	if driver == nil {
+		panic("vcs: Register driver is nil")
+	}
+	if _, dup := drivers[name]; dup {
+		panic("vcs: Register called twice for driver " + name)
+	}
+	drivers[name] = driver
+}
+
+func Clone(vcs, dir, url string) (string, error) {
+	driver, ok := drivers[vcs]
+	if !ok {
+		return "", fmt.Errorf("vcs: unknown driver %q", vcs)
+	}
+
+	return driver.Clone(dir, url)
+}
+
+func Pull(vcs, dir string) (string, error) {
+	driver, ok := drivers[vcs]
+	if !ok {
+		return "", fmt.Errorf("vcs: unknown driver %q", vcs)
+	}
+
+	return driver.Pull(dir)
+}
+
+func HeadHash(vcs, dir string) (string, error) {
+	driver, ok := drivers[vcs]
+	if !ok {
+		return "", fmt.Errorf("vcs: unknown driver %q", vcs)
+	}
+	return driver.HeadHash(dir)
+}
+
+func exists(path string) bool {
+	if _, err := os.Stat(path); err != nil {
+		return false
+	}
+	return true
+}
+
+func PullOrClone(vcs, dir, url string) (string, error) {
+	if exists(dir) {
+		return Pull(vcs, dir)
+	}
+	return Clone(vcs, dir, url)
+}


### PR DESCRIPTION
This was actually fairly painless. I refactored all repo accesses to use a new `hound/vcs` package (it replaces `hound/git`) which works similar to `database/sql` in that you can register plugins to handle operations.

The only odd thing is that in stead of doing `hg id -i`, I used `hg log -r tip --template '{node}'` which should give a 40 character sha, not the shorter one, as there's a regex used in existing that's somewhat lazy in looking at directory names.

Also, most of the hg plugin was a direct copy from the git plugin with a few renames. It might be worthwhile to clean it up a bit.

The config adds a new vcs option which allows you to specify the vcs of a repository. It defaults to git.

Docs have not been updated to say that mercurial is supported yet, as I'd like to get some feedback on this first.