### PR TITLE
Small fixes for Mercurial Pull and HeadHash

### DIFF
--- a/src/hound/vcs/hg.go
+++ b/src/hound/vcs/hg.go
@@ -21,7 +21,7 @@ func (g *MercurialDriver) HeadHash(dir string) (string, error) {
 		"hg",
 		"log",
 		"-r",
-		"tip",
+		".",
 		"--template",
 		"{node}")
 	cmd.Dir = dir
@@ -45,7 +45,7 @@ func (g *MercurialDriver) HeadHash(dir string) (string, error) {
 }
 
 func (g *MercurialDriver) Pull(dir string) (string, error) {
-	cmd := exec.Command("hg", "pull")
+	cmd := exec.Command("hg", "pull", "-u")
 	cmd.Dir = dir
 	err := cmd.Run()
 	if err != nil {


### PR DESCRIPTION
* Pull was just pulling in the code. `-u` will make pull also update the checked out repo to the latest revision.
* For revisions `tip` is simply the highest numbered revision, while `.` is the currently checked out revision.