### PR TITLE
Visually separate matches in one file

### DIFF
--- a/pub/assets/css/hound.css
+++ b/pub/assets/css/hound.css
@@ -282,6 +282,29 @@ button:focus {
   overflow: auto;
 }
 
+.matches {
+  /* Allow borders in .match grow to the end of line */
+  display: inline-block;
+  min-width: 100%;
+}
+
+.match {
+  margin: 10px 0;
+  border: 1px solid #d8d8d8;
+  border-left: none;
+  border-right: none;
+}
+
+.match:first-child {
+  margin-top: 0;
+  border-top: none;
+}
+
+.match:last-child {
+  margin-bottom: 0;
+  border-bottom: none;
+}
+
 .match > .line {
   white-space: pre;
 }

--- a/pub/assets/js/hound.js
+++ b/pub/assets/js/hound.js
@@ -639,7 +639,9 @@ var FilesView = React.createClass({
             </a>
           </div>
           <div className="file-body">
-            {matches}
+            <div className="matches">
+              {matches}
+            </div>
           </div>
         </div>
       );


### PR DESCRIPTION
Try to search "git" in this repo. There are more matches in README.md and I find it useful to visually separate grouped lines by margin and border.