### PR TITLE
Allow borders in .match div grow to the end of line

### DIFF
--- a/pub/assets/css/hound.css
+++ b/pub/assets/css/hound.css
@@ -281,6 +281,12 @@ button:focus {
   overflow: auto;
 }
 
+.matches {
+  /* Allow borders in .match grow to the end of line */
+  display: inline-block;
+  min-width: 100%;
+}
+
 .match {
   border-bottom: 2px solid #f0f0f0;
 }

--- a/pub/assets/js/hound.js
+++ b/pub/assets/js/hound.js
@@ -639,7 +639,9 @@ var FilesView = React.createClass({
             </a>
           </div>
           <div className="file-body">
-            {matches}
+            <div className="matches">
+              {matches}
+            </div>
           </div>
         </div>
       );


### PR DESCRIPTION
The ```matches``` div had purpose, sorry :-)

![screen shot 2015-02-01 at 00 22 57](https://cloud.githubusercontent.com/assets/2528846/5990251/9e0c75d4-a9a8-11e4-834d-7aafe6369036.png)