### PR TITLE
Add an element for user to hide advanced menu

### DIFF
--- a/pub/assets/css/hound.css
+++ b/pub/assets/css/hound.css
@@ -115,6 +115,11 @@ button:focus {
   transition: height, padding 0.1s ease-in-out;
 }
 
+#adv > .hideAdv {
+  color: #aaa;
+  text-decoration: underline;
+}
+
 /* Media object clearfix */
 #adv > .field {
   overflow: hidden;

--- a/pub/assets/js/hound.js
+++ b/pub/assets/js/hound.js
@@ -397,13 +397,16 @@ var SearchBar = React.createClass({
   },
   hideAdvanced: function() {
     var adv = this.refs.adv.getDOMNode(),
-        ban = this.refs.ban.getDOMNode();
+        ban = this.refs.ban.getDOMNode(),
+        q = this.refs.q.getDOMNode();
 
     css(adv, 'height', '0');
     css(adv, 'padding', '0');
 
     css(ban, 'max-height', '100px');
     css(ban, 'opacity', '1');
+
+    q.focus();
   },
   render: function() {
     var repoCount = this.state.allRepos.length,
@@ -448,6 +451,9 @@ var SearchBar = React.createClass({
 
         <div id="inb">
           <div id="adv" ref="adv">
+            <div className="hideAdv" onClick={this.hideAdvanced}>
+                Hide Advanced
+            </div>
             <div className="field">
               <label>File Path</label>
               <div className="field-input">


### PR DESCRIPTION
Provide a more visible way to hide the advanced menu.

![hound_hide_adv](https://cloud.githubusercontent.com/assets/667272/5996119/69e28ed8-aade-11e4-8c4c-164a2313c47e.gif)
