### PR TITLE
Set correct CORS header in API endpoint.

### DIFF
--- a/src/hound/api/api.go
+++ b/src/hound/api/api.go
@@ -25,7 +25,7 @@ type Stats struct {
 
 func writeJson(w http.ResponseWriter, data interface{}) {
 	w.Header().Set("Content-Type", "application/json;charset=utf-8")
-	w.Header().Set("Access-Control-Allow", "*")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
 	if err := json.NewEncoder(w).Encode(data); err != nil {
 		log.Panicf("Failed to encode JSON: %v\n", err)
 	}


### PR DESCRIPTION
The correct header string is 'Access-Control-Allow-Origin'.

See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS