### PR TITLE
Support bzr repositories + add a "name" field.

### DIFF
--- a/pub/assets/js/hound.js
+++ b/pub/assets/js/hound.js
@@ -265,6 +265,11 @@ var Model = {
       return repo;
     }
 
+    // Prefer the given name
+    if (info.name) {
+      return info.name;
+    }
+
     var url = info.url,
         ax = url.lastIndexOf('/');
     if (ax  < 0) {

--- a/src/hound/config/config.go
+++ b/src/hound/config/config.go
@@ -13,6 +13,7 @@ const (
 
 type Repo struct {
 	Url            string `json:"url"`
+	Name           string `json:"name"`
 	MsBetweenPolls int    `json:"ms-between-poll"`
 	VCS            string `json:"vcs"`
 }

--- a/src/hound/vcs/bzr.go
+++ b/src/hound/vcs/bzr.go
@@ -1,0 +1,69 @@
+package vcs
+
+import (
+	"bytes"
+	"io"
+	"log"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func init() {
+	RegisterVCS("bzr", &BzrDriver{})
+}
+
+type BzrDriver struct{}
+
+func (g *BzrDriver) HeadHash(dir string) (string, error) {
+	cmd := exec.Command(
+		"bzr",
+		"revno")
+	cmd.Dir = dir
+	r, err := cmd.StdoutPipe()
+	if err != nil {
+		return "", err
+	}
+	defer r.Close()
+
+	if err := cmd.Start(); err != nil {
+		return "", err
+	}
+
+	var buf bytes.Buffer
+
+	if _, err := io.Copy(&buf, r); err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(buf.String()), cmd.Wait()
+}
+
+func (g *BzrDriver) Pull(dir string) (string, error) {
+	cmd := exec.Command("bzr", "pull")
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Printf("Failed to bzr pull %s, see output below\n%sContinuing...", dir, out)
+		return "", err
+	}
+
+	return g.HeadHash(dir)
+}
+
+func (g *BzrDriver) Clone(dir, url string) (string, error) {
+	par, rep := filepath.Split(dir)
+	cmd := exec.Command(
+		"bzr",
+		"branch",
+		url,
+		rep)
+	cmd.Dir = par
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Printf("Failed to clone %s, see output below\n%sContinuing...", url, out)
+		return "", err
+	}
+
+	return g.HeadHash(dir)
+}


### PR DESCRIPTION
Hello,
we're starting to use this tool for our codebase but we're using bzr as a VCS.

This pull request adds support for bzr repositories (via the json configuration) and adds also an optional field called "name" that allows a different name to be displayed in the HTML page, this is due to the fact that bazaar branches have weird names that might be misleading, for example we have repo1/releases/2015-02 and repo2/releases/2015-02 and Hound's default behavior is to show only the latest part of the url (in this case "2015-02" which is not that helpful).

Feel free to merge if you're interested.