### PR TITLE
fix 404s for Github Enterprise repos (see #19)

### DIFF
--- a/pub/assets/js/hound.js
+++ b/pub/assets/js/hound.js
@@ -286,8 +286,11 @@ var Model = {
         url = info.url.replace(/\.git$/, ''),
         anc = line ? '#L' + line : '';
 
-    // Hacky solution to fix _some_ of the 404's when using SSH style URLs
-    url = url.replace("git@github.com:", 'https://www.github.com/');
+    // Hacky solution to fix _some more_ of the 404's when using SSH style URLs
+    var sshParts = /git@(.*):(.*)/i.exec(url);
+    if (sshParts) {
+      url = '//' + sshParts[1] + '/' + sshParts[2];
+    }
 
     return url + '/blob/master/' + path + anc;
   }


### PR DESCRIPTION
This is a slightly more flexible solution for #19 than
d2c1d98deb169f2539668d6992207a9e9d83b8dd, which worked for private
github.com repos but not for repos on a different domain.