### PR TITLE
Fix the naming issues in dbpath.

### DIFF
--- a/src/hound/cmds/houndd/main.go
+++ b/src/hound/cmds/houndd/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"flag"
 	"fmt"
 	"hound/api"
@@ -186,7 +185,7 @@ func makeSearchers(cfg *config.Config) (map[string]*searcher.Searcher, bool, err
 			delete(cfg.Repos, name)
 		}
 
-		return searchers, false, errors.New("One or more repos failed to index")
+		return searchers, false, nil
 	}
 
 	return searchers, true, nil

--- a/src/hound/searcher/searcher.go
+++ b/src/hound/searcher/searcher.go
@@ -237,6 +237,7 @@ func MakeAll(cfg *config.Config) (map[string]*Searcher, map[string]error, error)
 		s, err := newSearcher(cfg.DbPath, name, repo, manifests)
 		if err != nil {
 			errs[name] = err
+			continue
 		}
 
 		searchers[strings.ToLower(name)] = s


### PR DESCRIPTION
dbpath names are now:
vcs: vcs-{ SHA1 of repo.Url }
idx: idx-{ pseudo-random 64-bits }

The one downside of this change is we will always delete all indexes and rebuild them at startup. This is a thing that can be fixed though by writing a manifest into each of the idx directories.