### PR TITLE
Support linking to bitbucket style URLs

### DIFF
--- a/pub/assets/js/common.js
+++ b/pub/assets/js/common.js
@@ -10,21 +10,28 @@ var lib = {
       return template;
     },
 
-    UrlToRepo: function(repo, path, line) {
+    UrlToRepo: function(repo, path, line, rev) {
         var url = repo.url.replace(/\.git$/, ''),
             pattern = repo['url-pattern'],
             anchor = line ? lib.ExpandVars(pattern.anchor, { line : line }) : '';
 
-        // Hacky solution to fix _some more_ of the 404's when using SSH style URLs
-        var sshParts = /git@(.*):(.*)/i.exec(url);
+        // Hacky solution to fix _some more_ of the 404's when using SSH style URLs.
+        // This works for both github style URLs (git@github.com:username/Foo.git) and
+        // bitbucket style URLs (ssh://hg@bitbucket.org/username/Foo).
+
+        // Regex explained: Match either `git` or `hg` followed by an `@`.
+        // Next, slurp up the hostname by reading until either a `:` or `/` is found.
+        // Finally, grab all remaining characters.
+        var sshParts = /(git|hg)@(.*?)(:|\/)(.*)/.exec(url);
         if (sshParts) {
-          url = '//' + sshParts[1] + '/' + sshParts[2];
+          url = '//' + sshParts[2] + '/' + sshParts[4];
         }
 
         // I'm sure there is a nicer React/jsx way to do this:
         return lib.ExpandVars(pattern['base-url'], {
           url : url,
           path: path,
+          rev: rev,
           anchor: anchor
         });
     }

--- a/pub/assets/js/excluded_files.js
+++ b/pub/assets/js/excluded_files.js
@@ -2,7 +2,7 @@
 
 var ExcludedRow = React.createClass({
   render: function() {
-    var url = lib.UrlToRepo(this.props.repo, this.props.file.Filename);
+    var url = lib.UrlToRepo(this.props.repo, this.props.file.Filename, this.props.rev);
     return (
       <tr>
         <td className="name">

--- a/pub/assets/js/hound.js
+++ b/pub/assets/js/hound.js
@@ -193,6 +193,7 @@ var Model = {
           var res = matches[repo];
           results.push({
             Repo: repo,
+            Rev: res.Revision,
             Matches: res.Matches,
             FilesWithMatch: res.FilesWithMatch,
           });
@@ -281,8 +282,8 @@ var Model = {
     return url.substring(bx + 1, ax) + ' / ' + name;
   },
 
-  UrlToRepo: function(repo, path, line) {
-    return lib.UrlToRepo(this.repos[repo], path, line);
+  UrlToRepo: function(repo, path, line, rev) {
+    return lib.UrlToRepo(this.repos[repo], path, line, rev);
   }
 
 };
@@ -602,7 +603,8 @@ var FilesView = React.createClass({
   },
 
   render: function() {
-    var repo = this.props.repo,
+    var rev = this.props.rev,
+        repo = this.props.repo,
         regexp = this.props.regexp,
         matches = this.props.matches,
         totalMatches = this.props.totalMatches;
@@ -614,7 +616,7 @@ var FilesView = React.createClass({
           var content = ContentFor(line, regexp);
           return (
             <div className="line">
-              <a href={Model.UrlToRepo(repo, filename, line.Number)}
+              <a href={Model.UrlToRepo(repo, filename, line.Number, rev)}
                   className="lnum"
                   target="_blank">{line.Number}</a>
               <span className="lval" dangerouslySetInnerHTML={{__html:content}} />
@@ -630,7 +632,7 @@ var FilesView = React.createClass({
       return (
         <div className="file">
           <div className="title">
-            <a href={Model.UrlToRepo(repo, match.Filename)}>
+            <a href={Model.UrlToRepo(repo, match.Filename, null, rev)}>
               {match.Filename}
             </a>
           </div>
@@ -700,6 +702,7 @@ var ResultView = React.createClass({
             <span className="name">{Model.NameForRepo(result.Repo)}</span>
           </div>
           <FilesView matches={result.Matches}
+              rev={result.Rev}
               repo={result.Repo}
               regexp={regexp}
               totalMatches={result.FilesWithMatch} />

--- a/src/hound/index/index.go
+++ b/src/hound/index/index.go
@@ -20,6 +20,7 @@ type Snapshot string
 
 type Index struct {
 	dir string
+	rev string
 	idx *index.Index
 	lck sync.RWMutex
 }
@@ -44,6 +45,7 @@ type SearchResponse struct {
 	FilesWithMatch int
 	FilesOpened    int           `json:"-"`
 	Duration       time.Duration `json:"-"`
+	Revision       string
 }
 
 type FileMatch struct {
@@ -57,7 +59,7 @@ type ExcludedFile struct {
 }
 
 func (s Snapshot) Open() (*Index, error) {
-	return Open(string(s))
+	return Open(string(s), "")
 }
 
 func (n *Index) Destroy() error {
@@ -172,6 +174,7 @@ func (n *Index) Search(pat string, opt *SearchOptions) (*SearchResponse, error) 
 		FilesWithMatch: filesFound,
 		FilesOpened:    filesOpened,
 		Duration:       time.Now().Sub(startedAt),
+		Revision:       n.rev,
 	}, nil
 }
 
@@ -318,9 +321,10 @@ func Build(dst, src string) (Snapshot, error) {
 }
 
 // Open an existing snapshot
-func Open(dir string) (*Index, error) {
+func Open(dir, rev string) (*Index, error) {
 	return &Index{
 		dir: dir,
+		rev: rev,
 		idx: index.Open(filepath.Join(dir, "tri")),
 	}, nil
 }

--- a/src/hound/searcher/searcher.go
+++ b/src/hound/searcher/searcher.go
@@ -184,7 +184,7 @@ func buildAndOpenIndex(dbpath, vcsDir, idxDir, url, rev string) (*index.Index, e
 		}
 	}
 
-	return index.Open(idxDir)
+	return index.Open(idxDir, rev)
 }
 
 // Simply prints out statistics about the heap. When hound rebuilds a new


### PR DESCRIPTION
Bitbucket style URLs differ from github style URLs in two ways:

1) Bitbucket SSH repository URLs takes the form of:
`ssh://hg@bitbucket.org/username/Foo` (vs
`git@github.com:username/Foo.git`)
2) Direct links to source file lines require the commit hash/revision
id, following this pattern: `{url}/src/{rev}/{path}{anchor}`.

This patch addresses both these concerns to allow for direct file
linking to bitbucket.

This required a change to bubble up the revision to the UI layer, which
can be then fed in to the `UrlToRepo` function for final formatting via
a custom `url-pattern` (as defined above).

Server side, the `revision` value is bound to each `index` upon
opening. The `index.Search` function returns this value in the
`SearchResults` struct.