### PR TITLE
A better fix for the json marshalling/unmarshalling of vcs-config.

### DIFF
--- a/src/hound/config/config_test.go
+++ b/src/hound/config/config_test.go
@@ -28,7 +28,7 @@ func TestExampleConfigsAreValid(t *testing.T) {
 
 	// Ensure that each of the declared vcs's are legit
 	for _, repo := range cfg.Repos {
-		_, err := vcs.New(repo.Vcs, repo.VcsConfig)
+		_, err := vcs.New(repo.Vcs, repo.VcsConfig())
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/src/hound/searcher/searcher.go
+++ b/src/hound/searcher/searcher.go
@@ -224,7 +224,7 @@ func newSearcher(dbpath, name string, repo *config.Repo, refs *foundRefs) (*Sear
 
 	log.Printf("Searcher started for %s", name)
 
-	wd, err := vcs.New(repo.Vcs, repo.VcsConfig)
+	wd, err := vcs.New(repo.Vcs, repo.VcsConfig())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The issue I ran into earlier was simple, I needed VcsConfig to be
a *json.RawMessage instead of a json.RawMessage. But I did not want
to just fix that because it would have sent the vcs-config as JSON
to the client exposing any credentials that are stored there. I use
a trick here where I create a special type like json.RawMessage that
will preserve bytes in Unmarshal, but just emit {} in marshal.