### PR TITLE
Makefile - fixed `rm` cmd in the  `clean` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,4 +10,4 @@ ui/bindata.go: build/bin/go-bindata $(wildcard ui/assets/**/*)
 	$< -o $@ -pkg ui -prefix build/ui -nomemcopy build/ui/...
 
 clean:
-	rm -f build
+	rm -rf build


### PR DESCRIPTION
The `clean` target in the Makefile was missing the `r` flag.