### PR TITLE
Use .build instead of build so that go test works properly.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .vagrant
-build
+.build
 config.json

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 
 ALL: ui/bindata.go
 
-build/bin/go-bindata:
-	GOPATH=`pwd`/build go get github.com/jteeuwen/go-bindata/...
+.build/bin/go-bindata:
+	GOPATH=`pwd`/.build go get github.com/jteeuwen/go-bindata/...
 
-ui/bindata.go: build/bin/go-bindata $(wildcard ui/assets/**/*)
-	rsync -r --exclude '*.js' ui/assets/* build/ui
-	jsx --no-cache-dir ui/assets/js build/ui/js
-	$< -o $@ -pkg ui -prefix build/ui -nomemcopy build/ui/...
+ui/bindata.go: .build/bin/go-bindata $(wildcard ui/assets/**/*)
+	rsync -r --exclude '*.js' ui/assets/* .build/ui
+	jsx --no-cache-dir ui/assets/js .build/ui/js
+	$< -o $@ -pkg ui -prefix .build/ui -nomemcopy .build/ui/...
 
 clean:
-	rm -rf build
+	rm -rf .build


### PR DESCRIPTION
This solves a very practical problem with running the tests now. I want to be able to run all tests in the repository using `go get github.com/etsy/hound/...` but currently this tries to pick up the package that are in the `build` directory. Making this a dot directory hides it from the the recursive test discovery.