### PR TITLE
changed copy config to ONBUILD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang
 
 COPY . /go/src/github.com/etsy/hound
-COPY config.json /hound/
+ONBUILD COPY config.json /hound/
 RUN go-wrapper install github.com/etsy/hound/cmds/houndd
 
 EXPOSE 6080


### PR DESCRIPTION
If we use an ONBUILD instruction this container can be automatically build via docker.io
example https://registry.hub.docker.com/u/sstarcher/hound/

Once that is happening instead of cloning this repo and adding a config.json locally you could do the following.

Dockerfile
```
From sstarcher/hound
```
config.json
```
Whatever your config is
```

Those 2 files would be enough to run hound.