### PR TITLE
Use onbuild

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang
 
 COPY . /go/src/github.com/etsy/hound
-COPY config.json /hound/
+ONBUILD COPY config.json /hound/
 RUN go-wrapper install github.com/etsy/hound/cmds/houndd
 
 EXPOSE 6080

--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ Hound is an extremely fast source code search engine. The core is based on this 
 
 1. Create a [config.json](config-example.json) in a directory with your list of repositories.
 
-2. Run ```docker run -it --rm -p 0.0.0.0:6080:6080 --name houndd -v $(pwd):/hound etsy/hound```
+2. Run 
+    ```
+    docker run -it --rm -p 0.0.0.0:6080:6080 --name houndd -v $(pwd):/hound etsy/hound
+    ```
 
 You should be able to navigate to [http://localhost:6080/](http://localhost:6080/) as usual.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Hound is an extremely fast source code search engine. The core is based on this 
 
 2. Run 
     ```
-    docker run -it --rm -p 0.0.0.0:6080:6080 --name houndd -v $(pwd):/hound etsy/hound
+    docker run -it --rm -p 6080:6080 --name houndd -v $(pwd):/hound etsy/hound
     ```
 
 You should be able to navigate to [http://localhost:6080/](http://localhost:6080/) as usual.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Hound is an extremely fast source code search engine. The core is based on this 
 
 1. Create a [config.json](config-example.json) in a directory with your list of repositories.
 
-2. Run docker run -it --rm -p 0.0.0.0:6080:6080 --name houndd -v $(pwd):/hound etsy/hound
+2. Run ```docker run -it --rm -p 0.0.0.0:6080:6080 --name houndd -v $(pwd):/hound etsy/hound```
 
 You should be able to navigate to [http://localhost:6080/](http://localhost:6080/) as usual.
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,16 @@ Hound is an extremely fast source code search engine. The core is based on this 
 ![Hound Screen Capture](screen_capture.gif)
 
 ## Quick Start Guide
+* docker 1.4+
+
+1. Create a [config.json](config-example.json) in a directory with your list of repositories.
+
+2. Run docker run -it --rm -p 0.0.0.0:6080:6080 --name houndd -v $(pwd):/hound etsy/hound
+
+You should be able to navigate to [http://localhost:6080/](http://localhost:6080/) as usual.
+
+
+## Build from source
 
 1. Use the Go tools to install Hound. The binaries `houndd` (server) and `hound` (cli) will be installed in your $GOPATH.
 
@@ -16,7 +26,7 @@ Hound is an extremely fast source code search engine. The core is based on this 
     go get github.com/etsy/hound/cmds/...
     ```
 
-2. Create a [config.json](config-example.json) at the root of your GOPATH with your list of repositories.
+2. Create a [config.json](config-example.json) in a directory with your list of repositories.
 
 3. Run the Hound server with `houndd` and you should see output similer to:
 ````
@@ -46,15 +56,6 @@ Which brings us to...
 
 Yup, that's it. You can proxy requests to the Go service through Apache/nginx/etc., but that's not required.
 
-## Docker
-* docker 1.4+
-
-You should follow the quickstart guide up to step (3) and then run:
-
-    $ docker build -t houndd .
-    $ docker run -it --rm -p 0.0.0.0:6080:6080 --name houndd houndd
-
-You should be able to navigate to [http://localhost:6080/](http://localhost:6080/) as usual.
 
 ## Support
 


### PR DESCRIPTION
If we use an ONBUILD instruction this container can be automatically build via docker.io
example https://registry.hub.docker.com/u/sstarcher/hound/

Once that is happening instead of cloning this repo and adding a config.json locally you could do the following.

Dockerfile
```
From sstarcher/hound
```

config.json
```
{ ....}
```

Whatever your config is
Those 2 files would be enough to run hound.