### PR TITLE
Added "none" type VCS for indexing local directories

### DIFF
--- a/vcs/none.go
+++ b/vcs/none.go
@@ -1,0 +1,46 @@
+package vcs
+
+import (
+	"log"
+	"os/exec"
+	"path/filepath"
+)
+
+func init() {
+	Register(newNoneVcs, "none")
+}
+
+type NoneVcsDriver struct{}
+
+func newNoneVcs(b []byte) (Driver, error) {
+	return &NoneVcsDriver{}, nil
+}
+
+func (g *NoneVcsDriver) HeadRev(dir string) (string, error) {
+    return "n/a", nil
+}
+
+func (g *NoneVcsDriver) Pull(dir string) (string, error) {
+	return g.HeadRev(dir)
+}
+
+func (g *NoneVcsDriver) Clone(dir, url string) (string, error) {
+	par, rep := filepath.Split(dir)
+	cmd := exec.Command(
+		"cp",
+		"-r",
+		url[7:],
+		rep)
+	cmd.Dir = par
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Printf("Failed to clone %s, see output below\n%sContinuing...", url, out)
+		return "", err
+	}
+
+	return g.HeadRev(dir)
+}
+
+func (g *NoneVcsDriver) SpecialFiles() []string {
+	return []string{}
+}


### PR DESCRIPTION
This addresses #134. Please go easy on me, this is the first Go I've ever written and it may well be the worst you've ever seen. :smiley: 

I used the git VCS driver as inspiration and basically cut it done to nothing. I figured this approach was better than special-casing `file://` URLs as it a) has one less special case subverting the driver architecture and b) still allows for the scenario wherein a user wants to specify a `file://` URL pointing to a git repo.

I am happy to make any changes as you see fit.