### PR TITLE
Remove all utterances of github.com/etsy/Hound.

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Currently the following editors have plugins that support Hound:
 Hound includes tools to make building locally easy. It is recommended that you use these tools if you are working on Hound. To get setup and build, just run the following commands:
 
 ```
-git clone https://github.com/etsy/Hound.git hound/src/github.com/etsy/hound
+git clone https://github.com/etsy/hound.git hound/src/github.com/etsy/hound
 cd hound
 src/github.com/etsy/hound/tools/setup
 make

--- a/README.md
+++ b/README.md
@@ -97,9 +97,9 @@ Currently the following editors have plugins that support Hound:
 Hound includes tools to make building locally easy. It is recommended that you use these tools if you are working on Hound. To get setup and build, just run the following commands:
 
 ```
-git clone https://github.com/etsy/Hound.git hound/src/github.com/etsy/Hound
+git clone https://github.com/etsy/Hound.git hound/src/github.com/etsy/hound
 cd hound
-src/github.com/etsy/Hound/tools/setup
+src/github.com/etsy/hound/tools/setup
 make
 ```
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,17 +1,17 @@
 ALL: commands
 
-ASSETS=$(shell find src/github.com/etsy/Hound/ui/assets)
+ASSETS=$(shell find src/github.com/etsy/hound/ui/assets)
 
 bin/go-bindata:
 	GOPATH=$(shell pwd) go get github.com/jteeuwen/go-bindata/...
 
-src/github.com/etsy/Hound/ui/bindata.go: bin/go-bindata $(ASSETS)
+src/github.com/etsy/hound/ui/bindata.go: bin/go-bindata $(ASSETS)
 	mkdir -p build/ui
-	rsync -r --exclude '*.js' src/github.com/etsy/Hound/ui/assets/* build/ui
-	jsx --no-cache-dir src/github.com/etsy/Hound/ui/assets/js build/ui/js
+	rsync -r --exclude '*.js' src/github.com/etsy/hound/ui/assets/* build/ui
+	jsx --no-cache-dir src/github.com/etsy/hound/ui/assets/js build/ui/js
 	$< -o $@ -pkg ui -prefix build/ui -nomemcopy build/ui/...
 
-commands: src/github.com/etsy/Hound/ui/bindata.go
+commands: src/github.com/etsy/hound/ui/bindata.go
 	GOPATH=$(shell pwd) go install github.com/etsy/hound/cmds/...
 
 clean:

--- a/tools/setup
+++ b/tools/setup
@@ -25,9 +25,9 @@ def main():
 	tools = get_tools_directory()
 	if not has_valid_location(tools):
 		print >> sys.stderr, "The Hound repository should be in a directory like:"
-		print >> sys.stderr, "src/github.com/etsy/Hound"
+		print >> sys.stderr, "src/github.com/etsy/hound"
 		print >> sys.stderr, ""
-		print >> sys.stderr, "Follow the directions at https://github.com/etsy/Hound#editing--building"
+		print >> sys.stderr, "Follow the directions at https://github.com/etsy/hound#editing--building"
 		return 1
 	work = os.path.join(tools, '..', '..', '..', '..', '..')
 


### PR DESCRIPTION
I actually renamed the repo from Hound to hound and since it was just
a case change, none of the usual warnings appeared.