### PR TITLE
Minimal docker image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .build
 .DS_Store
 *.exe
+dist/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
-FROM golang
 
-COPY . /go/src/github.com/etsy/hound
-ONBUILD COPY config.json /hound/
-RUN go-wrapper install github.com/etsy/hound/cmds/houndd
-
-EXPOSE 6080
-
-ENTRYPOINT ["/go/bin/houndd", "-conf", "/hound/config.json"]
+FROM    alpine:edge
+RUN     apk -U add git
+COPY    dist/bin/houndd /houndd
+COPY    config.json /hound/config.json
+VOLUME  /hound/data
+EXPOSE  6080
+ENTRYPOINT ["/houndd", "-conf", "/hound/config.json"]

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,5 @@
+
+FROM    golang:1.5
+WORKDIR /go/src/github.com/etsy/hound
+ENV     CGO_ENABLED=0
+CMD     go-wrapper install -a github.com/etsy/hound/cmds/houndd

--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,30 @@ ui/bindata.go: .build/bin/go-bindata $(wildcard ui/assets/**/*)
 
 clean:
 	rm -rf .build
+
+
+BUILD_ID ?= $(shell git rev-parse --short HEAD 2>/dev/null)
+DOCKER_IMAGE := hound-dev:$(BUILD_ID)
+
+VOLUMES := \
+	-v $(CURDIR):/go/src/github.com/etsy/hound \
+	-v $(CURDIR)/dist/bin:/go/bin \
+	-v $(CURDIR)/dist/pkg:/go/pkg
+
+build:
+	docker build -t $(DOCKER_IMAGE) -f Dockerfile.build .
+
+dist:
+	mkdir dist/
+
+binary: dist build
+	docker run --rm $(VOLUMES) $(DOCKER_IMAGE)
+
+shell: dist build
+	docker run --rm -ti $(VOLUMES) $(DOCKER_IMAGE) bash
+
+build-image: binary
+	docker build -t etsy/hound:$(BUILD_ID) .
+
+test-unit: build
+	docker run --rm -ti $(VOLUMES) $(DOCKER_IMAGE) go test -v ./...


### PR DESCRIPTION
Hello,

Not sure if you're interested in this or not, but I worked on it for myself, so I thought I'd share.

This change splits the `Dockerfile` into two, one for building the binary (static) and another that uses a small base image for running the binary.  With this setup the deployed runtime image is 34M (the current one with golang base is ~500M I believe.

The Makefile supports a fully dockerized build process.