### PR TITLE
Delete and re-clone the repo if pull fails

### DIFF
--- a/searcher/searcher.go
+++ b/searcher/searcher.go
@@ -313,7 +313,7 @@ func updateAndReindex(
 	newRev, err := wd.PullOrClone(vcsDir, repo.Url)
 
 	if err != nil {
-		log.Printf("vcs pull error (%s - %s): %s", name, repo.Url, err)
+		log.Printf("vcs clone error (%s - %s): %s", name, repo.Url, err)
 		return rev, false
 	}
 

--- a/vcs/vcs.go
+++ b/vcs/vcs.go
@@ -71,7 +71,17 @@ func exists(path string) bool {
 // if the working directory is absent and pulling otherwise.
 func (w *WorkDir) PullOrClone(dir, url string) (string, error) {
 	if exists(dir) {
-		return w.Pull(dir)
+		newRev, err := w.Pull(dir)
+
+		if err == nil {
+			return newRev, err
+		}
+
+		log.Printf("vcs pull error (%s - %s): %s removing directory and re-cloning", dir, url, err)
+		if err := os.RemoveAll(dir); err != nil {
+			log.Printf("Error removing %s: %s", dir, err)
+		}
 	}
+
 	return w.Clone(dir, url)
 }


### PR DESCRIPTION
If a repo is forced pushed then a regular "git pull" will fail and hound will not index the latest repository contents.  This change should fix that issue by re-cloning if a pull operation fails.