### PR TITLE
Fix blank page in Internet Explorer

### DIFF
--- a/ui/assets/index.tpl.html
+++ b/ui/assets/index.tpl.html
@@ -2,6 +2,7 @@
 <html>
     <head>
         <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
         <title>Hound</title>
         <link rel="stylesheet" href="css/octicons/octicons.css">
         <link rel="stylesheet" href="css/hound.css">


### PR DESCRIPTION
I am seeing a blank page in IE10. Adding the "X-UA-Compatible" tag to the html fixes the issue.