### PR TITLE
Added options to speficy defaults for poll frequence and vcs

### DIFF
--- a/config-example.json
+++ b/config-example.json
@@ -1,6 +1,10 @@
 {
     "max-concurrent-indexers" : 2,
     "dbpath" : "data",
+    "repo-defaults" : {
+        "ms-between-poll" : 30000,
+        "vcs" : "git"
+    },
     "repos" : {
         "SomeGitRepo" : {
             "url" : "https://www.github.com/YourOrganization/RepoOne.git"


### PR DESCRIPTION
Added options to speficy defaults for ms-between-polls and vcs in config.json - if any of the attributes are not defined the hardcoded values in the code (30000, "git") will be used as in the current version of the application.

Example config.json

{
    "dbpath" : "data",
    "repo-defaults" : {
        "ms-between-poll" : 30000,
        "vcs" : "git"
    },
    "repos" : {
        "Hound" : {
            "url" : "https://www.github.com/etsy/Hound.git"
        }
    }
}