### PR TITLE
Only show pointer cursor on the chevron.

### DIFF
--- a/ui/assets/css/hound.css
+++ b/ui/assets/css/hound.css
@@ -103,7 +103,6 @@ button:focus {
   color: #aaa;
   font-size: 12px;
   line-height: 24px;
-  cursor: pointer;
   background-color: #fff;
 }
 
@@ -157,6 +156,7 @@ button:focus {
   transition: max-height, opacity 0.1s ease-in-out;
   opacity: 1;
   overflow: hidden;
+  cursor: pointer;
 }
 
 #inb > .ban > em {


### PR DESCRIPTION
Ensure that we show the pointer cursor on the advanced search pane when
closed, but only on the chevron when the pane is open.

Closes #184.