### PR TITLE
Dockerfile: Run houndd as unprivileged user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,10 @@ FROM golang
 
 COPY . /go/src/github.com/etsy/hound
 ONBUILD COPY config.json /hound/
+RUN adduser --uid 999 --gecos ,,, --disabled-password --home /hound hound
 RUN go-wrapper install github.com/etsy/hound/cmds/houndd
 
+USER hound
 EXPOSE 6080
 
 ENTRYPOINT ["/go/bin/houndd", "-conf", "/hound/config.json"]


### PR DESCRIPTION
Being root in a container is like being root on the host machine[1]. Houndd
doesn't need root priviliges so it can be run as unprivileged user.

[1] https://stackoverflow.com/questions/19054029/security-of-docker-as-it-runs-as-root-user