### PR TITLE
Dockerfile: Use golang alpine as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM golang
+FROM golang:alpine
 
 COPY . /go/src/github.com/etsy/hound
 ONBUILD COPY config.json /hound/
-RUN adduser --uid 999 --gecos ,,, --disabled-password --home /hound hound
-RUN go-wrapper install github.com/etsy/hound/cmds/houndd
+RUN adduser -u 999 -g ,,, -D -h /hound hound
+RUN go install github.com/etsy/hound/cmds/houndd
 
 USER hound
 EXPOSE 6080

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,10 @@ FROM golang
 
 COPY . /go/src/github.com/etsy/hound
 ONBUILD COPY config.json /hound/
+RUN adduser --uid 999 --gecos ,,, --disabled-password --home /hound hound
 RUN go-wrapper install github.com/etsy/hound/cmds/houndd
 
+USER hound
 EXPOSE 6080
 
 ENTRYPOINT ["/go/bin/houndd", "-conf", "/hound/config.json"]


### PR DESCRIPTION
Using `golang:alpine` allow to reduce build image size from 740.6 MB to
264 MB.