### PR TITLE
Smaller docker images golang:alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:alpine
 
 COPY . /go/src/github.com/etsy/hound
 ONBUILD COPY config.json /hound/
-RUN apk update && apk add git subversion mercurial
+RUN apk update && apk add git subversion mercurial bzr
 RUN go install github.com/etsy/hound/cmds/houndd
 
 EXPOSE 6080

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM golang
+FROM golang:alpine
 
 COPY . /go/src/github.com/etsy/hound
 ONBUILD COPY config.json /hound/
-RUN go-wrapper install github.com/etsy/hound/cmds/houndd
+RUN apk update && apk add git subversion mercurial
+RUN go install github.com/etsy/hound/cmds/houndd
 
 EXPOSE 6080
 


### PR DESCRIPTION
@fbochu This does make the image about 0.5x the size.

I need to look for options for the permissions. I hate the notion of running data-only containers but maybe that's just the way things are in docker.