### PR TITLE
openssh seams to be missing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV GOPATH /go
 COPY . /go/src/github.com/etsy/hound
 ONBUILD COPY config.json /hound/
 RUN apk update \
-	&& apk add go git subversion mercurial bzr \
+	&& apk add go git subversion mercurial bzr openssh \
 	&& go install github.com/etsy/hound/cmds/houndd \
 	&& apk del go \
 	&& rm -f /var/cache/apk/* \


### PR DESCRIPTION
While running Hound:

```
Cloning into 'vcs-2db7dbdc56d69442a4c1efbe143ef24504efc4a1'...
error: cannot run ssh: No such file or directory
```

To isolate, I shelled into the container and found that ssh was missing:
```
$ docker run -it --rm -p 80:6080 --entrypoint=/bin/sh --name houndd -v $(pwd):/hound etsy/hound -s
/ # ssh
/bin/sh: ssh: not found
```
