### PR TITLE
Simplify Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
 FROM alpine
 
 ENV GOPATH /go
+
 COPY . /go/src/github.com/etsy/hound
-ONBUILD COPY config.json /hound/
+
+COPY default-config.json /data/config.json
+
 RUN apk update \
 	&& apk add go git subversion mercurial bzr openssh \
 	&& go install github.com/etsy/hound/cmds/houndd \
@@ -10,6 +13,8 @@ RUN apk update \
 	&& rm -f /var/cache/apk/* \
 	&& rm -rf /go/src /go/pkg
 
+VOLUME ["/data"]
+
 EXPOSE 6080
 
-ENTRYPOINT ["/go/bin/houndd", "-conf", "/hound/config.json"]
+ENTRYPOINT ["/go/bin/houndd", "-conf", "/data/config.json"]

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ go get github.com/etsy/hound/cmds/...
 
 2. Run 
 ```
-docker run -it --rm -p 6080:6080 --name houndd -v $(pwd):/hound etsy/hound
+docker run -d -p 6080:6080 --name hound -v $(pwd):/data etsy/hound
 ```
 
 You should be able to navigate to [http://localhost:6080/](http://localhost:6080/) as usual.

--- a/default-config.json
+++ b/default-config.json
@@ -1,0 +1,8 @@
+{
+  "dbpath" : "db",
+  "repos" : {
+    "Hound" : {
+      "url" : "https://github.com/etsy/hound.git"
+    }
+  }
+}


### PR DESCRIPTION
We are currently misusing `ONBUILD` in our Dockerfile. The downside of that was that you couldn't even run the hound image without first creating a little config.json file. This update uses a `VOLUME` that already contains a minimal config.json (that indexes this repository) and it's trivial to use a volume on the command line to mount your custom config.