### PR TITLE
Add branching to git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .build
 .DS_Store
 *.exe
+.idea


### PR DESCRIPTION
This allows users to customize the ref to use from the branch. For example:

```json
  "vcs": "git",
  "vcs-config": {
    "ref": "releases/9.0"
},
```