### PR TITLE
Always use relative URLs for assets

### DIFF
--- a/ui/assets/js/excluded_files.js
+++ b/ui/assets/js/excluded_files.js
@@ -78,7 +78,7 @@ var FilterableExcludedFiles = React.createClass({
   getInitialState: function() {
     var _this = this;
     $.ajax({
-      url: '/api/v1/repos',
+      url: 'api/v1/repos',
       dataType: 'json',
       success: function(data) {
         _this.setState({ repos: data });
@@ -103,7 +103,7 @@ var FilterableExcludedFiles = React.createClass({
       repo: this.state.repos[repo],
     });
     $.ajax({
-      url: '/api/v1/excludes',
+      url: 'api/v1/excludes',
       data: {repo: repo},
       type: 'GET',
       dataType: 'json',

--- a/ui/assets/js/hound.js
+++ b/ui/assets/js/hound.js
@@ -139,7 +139,7 @@ var Model = {
     }
 
     $.ajax({
-      url: '/api/v1/repos',
+      url: 'api/v1/repos',
       dataType: 'json',
       success: function(data) {
         _this.repos = data;
@@ -181,7 +181,7 @@ var Model = {
     }
 
     $.ajax({
-      url: '/api/v1/search',
+      url: 'api/v1/search',
       data: params,
       type: 'GET',
       dataType: 'json',
@@ -249,7 +249,7 @@ var Model = {
     });
 
     $.ajax({
-      url: '/api/v1/search',
+      url: 'api/v1/search',
       data: params,
       type: 'GET',
       dataType: 'json',
@@ -453,7 +453,7 @@ var SearchBar = React.createClass({
       statsView = (
         <div className="stats">
           <div className="stats-left">
-            <a href="/excluded_files.html"
+            <a href="excluded_files.html"
               className="link-gray">
                 Excluded Files
             </a>

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -75,12 +75,12 @@ func renderForDev(w io.Writer, root string, c *content, cfg *config.Config, r *h
 	var buf bytes.Buffer
 	fmt.Fprintf(
 		&buf,
-		"<script src=\"/js/JSXTransformer-%s.js\"></script>\n",
+		"<script src=\"js/JSXTransformer-%s.js\"></script>\n",
 		ReactVersion)
 	for _, path := range c.sources {
 		fmt.Fprintf(
 			&buf,
-			"<script type=\"text/jsx\" src=\"/%s\"></script>",
+			"<script type=\"text/jsx\" src=\"%s\"></script>",
 			path)
 	}
 


### PR DESCRIPTION
This enables Hound to be served off arbitrary paths, not just /.

Fixes #188.