### PR TITLE
ui: Add option to hide/show an entire repo

### DIFF
--- a/ui/assets/js/hound.js
+++ b/ui/assets/js/hound.js
@@ -644,6 +644,11 @@ var FilesView = React.createClass({
         regexp = this.props.regexp,
         matches = this.props.matches,
         totalMatches = this.props.totalMatches;
+
+    if (this.props.shouldHide) {
+        return null;
+    }
+
     var files = matches.map(function(match, index) {
       var filename = match.Filename,
           blocks = CoalesceMatches(match.Matches);
@@ -704,7 +709,12 @@ var ResultView = React.createClass({
     });
   },
   getInitialState: function() {
-    return { results: null };
+    return { results: null, hiddenReposMap: {} };
+  },
+  toggleRepoDisplay: function(repo) {
+    var newHiddenReposMap = Object.assign({}, this.state.hiddenReposMap);
+    newHiddenReposMap[repo] = !newHiddenReposMap[repo];
+    this.setState({hiddenReposMap: newHiddenReposMap});
   },
   render: function() {
     if (this.state.error) {
@@ -730,18 +740,25 @@ var ResultView = React.createClass({
 
     var regexp = this.state.regexp,
         results = this.state.results || [];
+    var temphiddenReposMap = this.state.hiddenReposMap;
+    var temp = this.toggleRepoDisplay;
     var repos = results.map(function(result, index) {
+      var shouldHide = temphiddenReposMap[result.Repo];
+      var visibilityLabel = shouldHide ? "Show" : "Hide";
       return (
         <div className="repo">
           <div className="title">
             <span className="mega-octicon octicon-repo"></span>
             <span className="name">{Model.NameForRepo(result.Repo)}</span>
+            <span className="stats stats-right" id="toggle"
+                  onClick={temp.bind(this, result.Repo)}>{{visibilityLabel}}</span>
           </div>
           <FilesView matches={result.Matches}
               rev={result.Rev}
               repo={result.Repo}
               regexp={regexp}
-              totalMatches={result.FilesWithMatch} />
+              totalMatches={result.FilesWithMatch}
+              shouldHide={shouldHide} />
         </div>
       );
     });


### PR DESCRIPTION
Add a simple UI to hide and re-show an entire repo.

After hacking this I found https://github.com/etsy/hound/pull/235 which solves the same issue, though a bit differently. Either one is good with me, I would just love to see this feature in hound.

![screen shot 2017-02-02 at 9 17 21 am](https://cloud.githubusercontent.com/assets/1106201/22560543/df52b522-e929-11e6-8eaa-cf7567cc7e3a.png)
