### PR TITLE
Updates Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY . /go/src/github.com/etsy/hound
 COPY default-config.json /data/config.json
 
 RUN apk update \
-	&& apk add go git subversion mercurial bzr openssh \
+	&& apk add go git subversion libc-dev mercurial bzr openssh \
 	&& go install github.com/etsy/hound/cmds/houndd \
 	&& apk del go \
 	&& rm -f /var/cache/apk/* \


### PR DESCRIPTION
Current docker build using Dockerfile ends with error

```
# github.com/etsy/hound/cmds/houndd
/usr/lib/go/pkg/tool/linux_amd64/link: running gcc failed: exit status 1
/usr/lib/gcc/x86_64-alpine-linux-musl/6.2.1/../../../../x86_64-alpine-linux-musl/bin/ld: cannot find Scrt1.o: No such file or directory
/usr/lib/gcc/x86_64-alpine-linux-musl/6.2.1/../../../../x86_64-alpine-linux-musl/bin/ld: cannot find crti.o: No such file or directory
/usr/lib/gcc/x86_64-alpine-linux-musl/6.2.1/../../../../x86_64-alpine-linux-musl/bin/ld: cannot find -lpthread
/usr/lib/gcc/x86_64-alpine-linux-musl/6.2.1/../../../../x86_64-alpine-linux-musl/bin/ld: cannot find -lssp_nonshared
collect2: error: ld returned 1 exit status

The command '/bin/sh -c apk update 	&& apk add go git subversion mercurial bzr openssh 	&& go install github.com/etsy/hound/cmds/houndd 	&& apk del go 	&& rm -f /var/cache/apk/* 	&& rm -rf /go/src /go/pkg' returned a non-zero code: 2
```

Adding package libc-dev resolves build problems.