### PR TITLE
Add test target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,6 @@ ui/bindata.go: .build/bin/go-bindata $(wildcard ui/assets/**/*)
 
 clean:
 	rm -rf .build
+
+test:
+	go test ./...


### PR DESCRIPTION
The README mentions that you can run `make test` to run the tests, but there is no test target in the Makefile. This commit adds that rule.

Is this the right way to run tests in Go? 