### PR TITLE
Docker improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.dockerignore
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ RUN apk update \
 	&& rm -f /var/cache/apk/* \
 	&& rm -rf /go/src /go/pkg
 
+RUN addgroup -S hound && adduser -S -g hound hound
+USER hound
+
 VOLUME ["/data"]
 
 EXPOSE 6080

--- a/README.md
+++ b/README.md
@@ -30,7 +30,11 @@ go get github.com/etsy/hound/cmds/...
 
 ### Using Docker (1.4+)
 
-1. Create a [config.json](config-example.json) in a directory with your list of repositories.
+1. Create a [config.json](config-example.json) in a directory with your list of repositories. This directory should be writable by other users.
+```
+chmod ugo+r config.json
+chmod 777 .
+```
 
 2. Run 
 ```


### PR DESCRIPTION
This makes two changes to the Docker build:

* It excludes the Dockerfile from the build process, so we can make changes to the Dockerfile and Docker uses its layer cache
* It changes the container to run as a `hound` user rather than root, according to [docker best practices](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/). This also makes it possible to run the Hound container on an NFS mount with root squashing.