### PR TITLE
Fix xml parsing of open_search.xml

### DIFF
--- a/ui/content.go
+++ b/ui/content.go
@@ -1,9 +1,6 @@
 package ui
 
-import (
-	htemplate "html/template"
-	ttemplate "text/template"
-)
+import "io"
 
 // Current versions of some dependencies.
 const (
@@ -12,6 +9,15 @@ const (
 )
 
 var contents map[string]*content
+
+// This interface abstracts the Execute method on template which is
+// structurally similar in both html/template and text/template.
+// We need to use an interface instead of a direct template field
+// because then we will need two different fields for html template
+// and text template.
+type renderer interface {
+	Execute(w io.Writer, data interface{}) error
+}
 
 type content struct {
 
@@ -24,13 +30,8 @@ type content struct {
 	// The JavaScript sources used in this HTML page
 	sources []string
 
-	// This is only created in prd-mode, the pre-parsed template
-	// HTML template - used for serving HTML content
-	htpl *htemplate.Template
-
-	// This is only created in prd-mode, the pre-parsed template
-	// Text template - currently used for /open_search.xml only
-	ttpl *ttemplate.Template
+	// The parsed template - can be of html/template or text/template type
+	tpl renderer
 
 	// This is used to determine if a template is to be parsed as text or html
 	tplType string

--- a/ui/content.go
+++ b/ui/content.go
@@ -1,6 +1,9 @@
 package ui
 
-import "html/template"
+import (
+	htemplate "html/template"
+	ttemplate "text/template"
+)
 
 // Current versions of some dependencies.
 const (
@@ -22,7 +25,15 @@ type content struct {
 	sources []string
 
 	// This is only created in prd-mode, the pre-parsed template
-	tpl *template.Template
+	// HTML template - used for serving HTML content
+	htpl *htemplate.Template
+
+	// This is only created in prd-mode, the pre-parsed template
+	// Text template - currently used for /open_search.xml only
+	ttpl *ttemplate.Template
+
+	// This is used to determine if a template is to be parsed as text or html
+	tplType string
 }
 
 func init() {
@@ -36,10 +47,12 @@ func init() {
 				"js/common.js",
 				"js/hound.js",
 			},
+			tplType: "html",
 		},
 
 		"/open_search.xml": &content{
 			template: "open_search.tpl.xml",
+			tplType: "xml",
 		},
 
 		"/excluded_files.html": &content{
@@ -48,6 +61,7 @@ func init() {
 				"js/common.js",
 				"js/excluded_files.js",
 			},
+			tplType: "html",
 		},
 	}
 }

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -2,8 +2,10 @@ package ui
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
-	"html/template"
+	htemplate "html/template"
+	ttemplate "text/template"
 	"io"
 	"log"
 	"net/http"
@@ -61,7 +63,21 @@ func (h *devHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // Renders a templated asset in dev-mode. This simply embeds external script tags
 // for the source elements.
 func renderForDev(w io.Writer, root string, c *content, cfg *config.Config, r *http.Request) error {
-	t, err := template.ParseFiles(
+	// If the requested asset is of type xml or text, short cut the execution
+	// using text/template package.
+	// See - https://github.com/etsy/hound/issues/239
+	if c.tplType == "xml" || c.tplType == "text" {
+		t, err := ttemplate.ParseFiles(
+			filepath.Join(root, c.template))
+		if err != nil {
+			return err
+		}
+		return t.Execute(w, map[string]interface{}{
+			"Host": r.Host,
+		})
+	}
+
+	t, err := htemplate.ParseFiles(
 		filepath.Join(root, c.template))
 	if err != nil {
 		return err
@@ -88,7 +104,7 @@ func renderForDev(w io.Writer, root string, c *content, cfg *config.Config, r *h
 		"ReactVersion":  ReactVersion,
 		"jQueryVersion": JQueryVersion,
 		"ReposAsJson":   json,
-		"Source":        template.HTML(buf.String()),
+		"Source":        htemplate.HTML(buf.String()),
 		"Host":          r.Host,
 	})
 }
@@ -133,6 +149,14 @@ func (h *prdHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // Renders a templated asset in prd-mode. This strategy will embed
 // the sources directly in a script tag on the templated page.
 func renderForPrd(w io.Writer, c *content, cfgJson string, r *http.Request) error {
+	// If the requested asset is of type xml or text, short cut the execution
+	// using text/template package.
+	// See - https://github.com/etsy/hound/issues/239
+	if c.tplType == "xml" || c.tplType == "text" {
+		return c.ttpl.Execute(w, map[string]interface{}{
+			"Host": r.Host,
+		})
+	}
 
 	var buf bytes.Buffer
 	buf.WriteString("<script>")
@@ -145,11 +169,11 @@ func renderForPrd(w io.Writer, c *content, cfgJson string, r *http.Request) erro
 	}
 	buf.WriteString("</script>")
 
-	return c.tpl.Execute(w, map[string]interface{}{
+	return c.htpl.Execute(w, map[string]interface{}{
 		"ReactVersion":  ReactVersion,
 		"jQueryVersion": JQueryVersion,
 		"ReposAsJson":   cfgJson,
-		"Source":        template.HTML(buf.String()),
+		"Source":        htemplate.HTML(buf.String()),
 		"Host":          r.Host,
 	})
 }
@@ -185,9 +209,24 @@ func newPrdHandler(cfg *config.Config) (http.Handler, error) {
 			return nil, err
 		}
 
-		cnt.tpl, err = template.New(cnt.template).Parse(string(a))
-		if err != nil {
-			return nil, err
+		// For more context, see: https://github.com/etsy/hound/issues/239
+		switch cnt.tplType {
+		case "html":
+			// Use html/template to parse the html template
+			cnt.htpl, err = htemplate.New(cnt.template).Parse(string(a))
+			if err != nil {
+				return nil, err
+			}
+		case "xml", "text":
+			// Use text/template to parse the xml or text templates
+			// We are using text/template here for parsing xml to keep things
+			// consistent with html/template parsing.
+			cnt.ttpl, err = ttemplate.New(cnt.template).Parse(string(a))
+			if err != nil {
+				return nil, err
+			}
+		default:
+			return nil, errors.New("invalid tplType for content")
 		}
 	}
 

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	htemplate "html/template"
-	ttemplate "text/template"
+	html_template "html/template"
+	text_template "text/template"
 	"io"
 	"log"
 	"net/http"
@@ -68,7 +68,7 @@ func renderForDev(w io.Writer, root string, c *content, cfg *config.Config, r *h
 	switch c.tplType {
 	case "html":
 		// Use html/template to parse the html template
-		c.tpl, err = htemplate.ParseFiles(filepath.Join(root, c.template))
+		c.tpl, err = html_template.ParseFiles(filepath.Join(root, c.template))
 		if err != nil {
 			return err
 		}
@@ -76,7 +76,7 @@ func renderForDev(w io.Writer, root string, c *content, cfg *config.Config, r *h
 		// Use text/template to parse the xml or text templates
 		// We are using text/template here for parsing xml to keep things
 		// consistent with html/template parsing.
-		c.tpl, err = ttemplate.ParseFiles(filepath.Join(root, c.template))
+		c.tpl, err = text_template.ParseFiles(filepath.Join(root, c.template))
 		if err != nil {
 			return err
 		}
@@ -105,7 +105,7 @@ func renderForDev(w io.Writer, root string, c *content, cfg *config.Config, r *h
 		"ReactVersion":  ReactVersion,
 		"jQueryVersion": JQueryVersion,
 		"ReposAsJson":   json,
-		"Source":        htemplate.HTML(buf.String()),
+		"Source":        html_template.HTML(buf.String()),
 		"Host":          r.Host,
 	})
 }
@@ -165,7 +165,7 @@ func renderForPrd(w io.Writer, c *content, cfgJson string, r *http.Request) erro
 		"ReactVersion":  ReactVersion,
 		"jQueryVersion": JQueryVersion,
 		"ReposAsJson":   cfgJson,
-		"Source":        htemplate.HTML(buf.String()),
+		"Source":        html_template.HTML(buf.String()),
 		"Host":          r.Host,
 	})
 }
@@ -205,7 +205,7 @@ func newPrdHandler(cfg *config.Config) (http.Handler, error) {
 		switch cnt.tplType {
 		case "html":
 			// Use html/template to parse the html template
-			cnt.tpl, err = htemplate.New(cnt.template).Parse(string(a))
+			cnt.tpl, err = html_template.New(cnt.template).Parse(string(a))
 			if err != nil {
 				return nil, err
 			}
@@ -213,7 +213,7 @@ func newPrdHandler(cfg *config.Config) (http.Handler, error) {
 			// Use text/template to parse the xml or text templates
 			// We are using text/template here for parsing xml to keep things
 			// consistent with html/template parsing.
-			cnt.tpl, err = ttemplate.New(cnt.template).Parse(string(a))
+			cnt.tpl, err = text_template.New(cnt.template).Parse(string(a))
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
This turned out to be more cumbersome than I had expected it to be. Below
is the description of what I did and the rationale behind it.

open_search.xml file was being served using html/template package and
since it doesn't know about xml contexts, it changes the first character
of xml template "<" into "\&lt;".

Now, we use two different packages:
- html/template - for parsing html template files
- text/template - for parsing text or xml template files

Here it's arguable that we could use encoding/xml package to parse the
xml template files in a better way. However, to keep the parsing logic
consistent, we are fine with using text/template only. If, in future, we
come across a use case where we want to parse and serve xml file where
we need to know the xml context while parsing the template, we may think
of switching to encoding/xml at the cost of inconsistency. There's no
need as of now to use it, because it's a very simple xml file.

Fixes #239 
/cc @stanistan 