### PR TITLE
index: fix warning coming from use of %s in Fatal

### DIFF
--- a/index/index_test.go
+++ b/index/index_test.go
@@ -91,7 +91,7 @@ func TestRead(t *testing.T) {
 	}
 
 	if r.Rev != rev {
-		t.Fatal("expected rev of %s, got %s", rev, r.Rev)
+		t.Fatalf("expected rev of %s, got %s", rev, r.Rev)
 	}
 
 	idx, err := r.Open()


### PR DESCRIPTION
Fatal doesn't allow use of formatting directive like %s. Instead, Fatalf
should be used when we need formatting directives.

Fixes - https://travis-ci.org/etsy/hound/jobs/305180308#L493

@stanistan this should be merged first of all so that other pull requests can be rebased on top of this commit to get a fair run of tests on travis.