### PR TITLE
travis: add more recent go versions until 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ go:
   - 1.3
   - 1.4
   - 1.5
+  - 1.6
+  - 1.7
+  - 1.8
+  - 1.9
   - tip
 install: go get ./...
 script: go test ./...


### PR DESCRIPTION
Add golang versions 1.6, 1.7, 1.8 and 1.9 to automated tests.