### PR TITLE
searcher: make indexing of repos concurrent

### DIFF
--- a/searcher/searcher.go
+++ b/searcher/searcher.go
@@ -296,7 +296,8 @@ func MakeAll(cfg *config.Config) (map[string]*Searcher, map[string]error, error)
 	}
 
 	// Collect the results on resultCh channel for all repos.
-	for range cfg.Repos {
+	n := len(cfg.Repos)
+	for i := 0; i < n; i++ {
 		r := <-resultCh
 		if r.err != nil {
 			log.Print(r.err)

--- a/searcher/searcher.go
+++ b/searcher/searcher.go
@@ -501,7 +501,6 @@ func newSearcherConcurrent(
 	if err != nil {
 		resultCh <- searcherResult{
 			name:     name,
-			searcher: nil,
 			err:      err,
 		}
 		return
@@ -510,6 +509,5 @@ func newSearcherConcurrent(
 	resultCh <- searcherResult{
 		name:     name,
 		searcher: s,
-		err:      nil,
 	}
 }

--- a/searcher/searcher.go
+++ b/searcher/searcher.go
@@ -286,8 +286,9 @@ func MakeAll(cfg *config.Config) (map[string]*Searcher, map[string]error, error)
 
 	lim := makeLimiter(cfg.MaxConcurrentIndexers)
 
+	n := len(cfg.Repos)
 	// Channel to receive the results from newSearcherConcurrent function.
-	resultCh := make(chan searcherResult)
+	resultCh := make(chan searcherResult, n)
 
 	// Start new searchers for all repos in different go routines while
 	// respecting cfg.MaxConcurrentIndexers.
@@ -296,7 +297,6 @@ func MakeAll(cfg *config.Config) (map[string]*Searcher, map[string]error, error)
 	}
 
 	// Collect the results on resultCh channel for all repos.
-	n := len(cfg.Repos)
 	for i := 0; i < n; i++ {
 		r := <-resultCh
 		if r.err != nil {

--- a/searcher/searcher.go
+++ b/searcher/searcher.go
@@ -287,7 +287,7 @@ func MakeAll(cfg *config.Config) (map[string]*Searcher, map[string]error, error)
 	lim := makeLimiter(cfg.MaxConcurrentIndexers)
 
 	// Channel to receive the results from newSearcherConcurrent function.
-	resultCh := make(chan searcherResult, 1)
+	resultCh := make(chan searcherResult)
 
 	// Start new searchers for all repos in different go routines while
 	// respecting cfg.MaxConcurrentIndexers.


### PR DESCRIPTION
This patch attempts to improve the startup time of hound vastly in cases
when we have huge number of repositories and hound would generally take
long time to start because of its sequential nature of indexing.

Now, we have the startup indexing in a concurrent way while respecting
the config.MaxConcurrentIndexers parameter set by users in config.json.

Fixes https://github.com/etsy/hound/issues/250