### PR TITLE
Add the ability to respond to health checks prior to indexes being built.

### DIFF
--- a/cmds/houndd/main.go
+++ b/cmds/houndd/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/etsy/hound/config"
 	"github.com/etsy/hound/searcher"
 	"github.com/etsy/hound/ui"
+	"github.com/etsy/hound/web"
 )
 
 const gracefulShutdownSignal = syscall.SIGTERM
@@ -128,6 +129,9 @@ func main() {
 		panic(err)
 	}
 
+	// Start the web server on a background routine.
+	ws := web.Start(&cfg, *flagAddr, *flagDev)
+
 	// It's not safe to be killed during makeSearchers, so register the
 	// shutdown signal here and defer processing it until we are ready.
 	shutdownCh := registerShutdownSignal()
@@ -162,7 +166,6 @@ func main() {
 
 	info_log.Printf("running server at http://%s...\n", host)
 
-	if err := runHttp(*flagAddr, *flagDev, &cfg, idx); err != nil {
-		panic(err)
-	}
+	// Fully enable the web server now that we have indexes
+	panic(ws.ServeWithIndex(idx))
 }

--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,7 @@ const (
 	defaultVcs                   = "git"
 	defaultBaseUrl               = "{url}/blob/master/{path}{anchor}"
 	defaultAnchor                = "#L{line}"
+	defaultHealthChekURI         = "/healthz"
 )
 
 type UrlPattern struct {
@@ -56,6 +57,7 @@ type Config struct {
 	DbPath                string           `json:"dbpath"`
 	Repos                 map[string]*Repo `json:"repos"`
 	MaxConcurrentIndexers int              `json:"max-concurrent-indexers"`
+	HealthCheckURI        string           `json:"health-check-uri"`
 }
 
 // SecretMessage is just like json.RawMessage but it will not
@@ -116,6 +118,10 @@ func initRepo(r *Repo) {
 func initConfig(c *Config) {
 	if c.MaxConcurrentIndexers == 0 {
 		c.MaxConcurrentIndexers = defaultMaxConcurrentIndexers
+	}
+
+	if c.HealthCheckURI == "" {
+		c.HealthCheckURI = defaultHealthChekURI
 	}
 }
 

--- a/ui/bindata.go
+++ b/ui/bindata.go
@@ -104,7 +104,7 @@ func cssHoundCss() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "css/hound.css", size: 6037, mode: os.FileMode(420), modTime: time.Unix(1534724948, 0)}
+	info := bindataFileInfo{name: "css/hound.css", size: 6037, mode: os.FileMode(420), modTime: time.Unix(1541106829, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -124,7 +124,7 @@ func cssOcticonsLicenseTxt() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "css/octicons/LICENSE.txt", size: 293, mode: os.FileMode(420), modTime: time.Unix(1534724948, 0)}
+	info := bindataFileInfo{name: "css/octicons/LICENSE.txt", size: 293, mode: os.FileMode(420), modTime: time.Unix(1541106829, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -144,7 +144,7 @@ func cssOcticonsReadmeMd() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "css/octicons/README.md", size: 200, mode: os.FileMode(420), modTime: time.Unix(1534724948, 0)}
+	info := bindataFileInfo{name: "css/octicons/README.md", size: 200, mode: os.FileMode(420), modTime: time.Unix(1541106829, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -164,7 +164,7 @@ func cssOcticonsOcticonsLocalTtf() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "css/octicons/octicons-local.ttf", size: 52764, mode: os.FileMode(420), modTime: time.Unix(1534724948, 0)}
+	info := bindataFileInfo{name: "css/octicons/octicons-local.ttf", size: 52764, mode: os.FileMode(420), modTime: time.Unix(1541106829, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -184,7 +184,7 @@ func cssOcticonsOcticonsCss() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "css/octicons/octicons.css", size: 11740, mode: os.FileMode(420), modTime: time.Unix(1534724948, 0)}
+	info := bindataFileInfo{name: "css/octicons/octicons.css", size: 11740, mode: os.FileMode(420), modTime: time.Unix(1541106829, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -204,7 +204,7 @@ func cssOcticonsOcticonsEot() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "css/octicons/octicons.eot", size: 31440, mode: os.FileMode(420), modTime: time.Unix(1534724948, 0)}
+	info := bindataFileInfo{name: "css/octicons/octicons.eot", size: 31440, mode: os.FileMode(420), modTime: time.Unix(1541106829, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -224,7 +224,7 @@ func cssOcticonsOcticonsLess() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "css/octicons/octicons.less", size: 12018, mode: os.FileMode(420), modTime: time.Unix(1534724948, 0)}
+	info := bindataFileInfo{name: "css/octicons/octicons.less", size: 12018, mode: os.FileMode(420), modTime: time.Unix(1541106829, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -244,7 +244,7 @@ func cssOcticonsOcticonsSvg() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "css/octicons/octicons.svg", size: 86997, mode: os.FileMode(420), modTime: time.Unix(1534724948, 0)}
+	info := bindataFileInfo{name: "css/octicons/octicons.svg", size: 86997, mode: os.FileMode(420), modTime: time.Unix(1541106829, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -264,7 +264,7 @@ func cssOcticonsOcticonsTtf() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "css/octicons/octicons.ttf", size: 31272, mode: os.FileMode(420), modTime: time.Unix(1534724948, 0)}
+	info := bindataFileInfo{name: "css/octicons/octicons.ttf", size: 31272, mode: os.FileMode(420), modTime: time.Unix(1541106829, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -284,7 +284,7 @@ func cssOcticonsOcticonsWoff() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "css/octicons/octicons.woff", size: 17492, mode: os.FileMode(420), modTime: time.Unix(1534724948, 0)}
+	info := bindataFileInfo{name: "css/octicons/octicons.woff", size: 17492, mode: os.FileMode(420), modTime: time.Unix(1541106829, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -304,7 +304,7 @@ func cssOcticonsSprocketsOcticonsScss() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "css/octicons/sprockets-octicons.scss", size: 11758, mode: os.FileMode(420), modTime: time.Unix(1534724948, 0)}
+	info := bindataFileInfo{name: "css/octicons/sprockets-octicons.scss", size: 11758, mode: os.FileMode(420), modTime: time.Unix(1541106829, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -324,7 +324,7 @@ func excluded_filesTplHtml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "excluded_files.tpl.html", size: 459, mode: os.FileMode(420), modTime: time.Unix(1534724948, 0)}
+	info := bindataFileInfo{name: "excluded_files.tpl.html", size: 459, mode: os.FileMode(420), modTime: time.Unix(1541106829, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -344,7 +344,7 @@ func faviconIco() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "favicon.ico", size: 1150, mode: os.FileMode(420), modTime: time.Unix(1534724948, 0)}
+	info := bindataFileInfo{name: "favicon.ico", size: 1150, mode: os.FileMode(420), modTime: time.Unix(1541106829, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -364,7 +364,7 @@ func imagesBusyGif() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "images/busy.gif", size: 4178, mode: os.FileMode(420), modTime: time.Unix(1534724948, 0)}
+	info := bindataFileInfo{name: "images/busy.gif", size: 4178, mode: os.FileMode(420), modTime: time.Unix(1541106829, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -384,7 +384,7 @@ func indexTplHtml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "index.tpl.html", size: 797, mode: os.FileMode(420), modTime: time.Unix(1534724948, 0)}
+	info := bindataFileInfo{name: "index.tpl.html", size: 797, mode: os.FileMode(420), modTime: time.Unix(1541106829, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -404,7 +404,7 @@ func jsJsxtransformer0122Js() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "js/JSXTransformer-0.12.2.js", size: 471852, mode: os.FileMode(420), modTime: time.Unix(1534724948, 0)}
+	info := bindataFileInfo{name: "js/JSXTransformer-0.12.2.js", size: 471852, mode: os.FileMode(420), modTime: time.Unix(1541106829, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -424,7 +424,7 @@ func jsCommonJs() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "js/common.js", size: 1503, mode: os.FileMode(420), modTime: time.Unix(1534724948, 0)}
+	info := bindataFileInfo{name: "js/common.js", size: 1503, mode: os.FileMode(420), modTime: time.Unix(1541106829, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -444,7 +444,7 @@ func jsExcluded_filesJs() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "js/excluded_files.js", size: 4081, mode: os.FileMode(420), modTime: time.Unix(1534724950, 0)}
+	info := bindataFileInfo{name: "js/excluded_files.js", size: 4081, mode: os.FileMode(420), modTime: time.Unix(1541106831, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -464,7 +464,7 @@ func jsHoundJs() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "js/hound.js", size: 13838, mode: os.FileMode(420), modTime: time.Unix(1534724950, 0)}
+	info := bindataFileInfo{name: "js/hound.js", size: 13838, mode: os.FileMode(420), modTime: time.Unix(1541106831, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -484,7 +484,7 @@ func jsJquery213MinJs() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "js/jquery-2.1.3.min.js", size: 84320, mode: os.FileMode(420), modTime: time.Unix(1534724948, 0)}
+	info := bindataFileInfo{name: "js/jquery-2.1.3.min.js", size: 84320, mode: os.FileMode(420), modTime: time.Unix(1541106829, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -504,7 +504,7 @@ func jsReact0122MinJs() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "js/react-0.12.2.min.js", size: 130436, mode: os.FileMode(420), modTime: time.Unix(1534724948, 0)}
+	info := bindataFileInfo{name: "js/react-0.12.2.min.js", size: 130436, mode: os.FileMode(420), modTime: time.Unix(1541106829, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -524,7 +524,7 @@ func open_searchTplXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "open_search.tpl.xml", size: 351, mode: os.FileMode(420), modTime: time.Unix(1534724948, 0)}
+	info := bindataFileInfo{name: "open_search.tpl.xml", size: 351, mode: os.FileMode(420), modTime: time.Unix(1541106829, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/web/web.go
+++ b/web/web.go
@@ -1,0 +1,85 @@
+package web
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+
+	"github.com/etsy/hound/api"
+	"github.com/etsy/hound/config"
+	"github.com/etsy/hound/searcher"
+	"github.com/etsy/hound/ui"
+)
+
+// Server is an HTTP server that handles all
+// http traffic for hound. It is able to serve
+// some traffic before indexes are built and
+// then transition to all traffic afterwards.
+type Server struct {
+	cfg *config.Config
+	dev bool
+	ch  chan error
+
+	mux *http.ServeMux
+	lck sync.RWMutex
+}
+
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path == s.cfg.HealthCheckURI {
+		fmt.Fprintln(w, "👍")
+		return
+	}
+
+	s.lck.RLock()
+	defer s.lck.RUnlock()
+	if m := s.mux; m != nil {
+		m.ServeHTTP(w, r)
+	} else {
+		http.Error(w,
+			"Hound is not ready.",
+			http.StatusServiceUnavailable)
+	}
+}
+
+func (s *Server) serveWith(m *http.ServeMux) {
+	s.lck.Lock()
+	defer s.lck.Unlock()
+	s.mux = m
+}
+
+// Start creates a new server that will immediately start handling HTTP traffic.
+// The HTTP server will return 200 on the health check, but a 503 on every other
+// request until ServeWithIndex is called to begin serving search traffic with
+// the given searchers.
+func Start(cfg *config.Config, addr string, dev bool) *Server {
+	ch := make(chan error)
+
+	s := &Server{
+		cfg: cfg,
+		dev: dev,
+		ch:  ch,
+	}
+
+	go func() {
+		ch <- http.ListenAndServe(addr, s)
+	}()
+
+	return s
+}
+
+// ServeWithIndex allow the server to start offering the search UI and the
+// search APIs operating on the given indexes.
+func (s *Server) ServeWithIndex(idx map[string]*searcher.Searcher) error {
+	h, err := ui.Content(s.dev, s.cfg)
+	if err != nil {
+		return err
+	}
+
+	m := http.NewServeMux()
+	m.Handle("/", h)
+	api.Setup(m, idx)
+
+	s.serveWith(m)
+
+	return <-s.ch
+}


### PR DESCRIPTION
It is really difficult to run Hound in kubernetes right now because the time it takes to build all the indexes and start serving HTTP traffic can vary widely. The readiness probe has to be constantly adjusted as you change your configuration. This change brings up the HTTP server before the searchers are made. But while the initial indexes are building, only the health check will return a 200 response, all other routes will return 503. Once the indexes are ready, all routes will be enabled.